### PR TITLE
Fix pkgdown config?

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -13,6 +13,7 @@ reference:
 - title: Metadata
   contents:
   - has_concept("meta")
+  - dcmi_terms
 - title: Miscellaneous
   contents:
   - has_concept("misc")


### PR DESCRIPTION
```r
Error in check_missing_topics(rows, pkg) : 
  All topics must be included in reference index
• Missing topics: dcmi_terms
```

or maybe that topic is missing a keyword?